### PR TITLE
Use parameter for involved_obj["apiVersion"]

### DIFF
--- a/plugins/modules/k8s_event.py
+++ b/plugins/modules/k8s_event.py
@@ -277,7 +277,7 @@ class KubernetesEvent(AnsibleModule):
         involved_obj = self.params.get("involvedObject")
         if involved_obj:
             try:
-                involved_object_resource = find_resource(self.client, involved_obj["kind"], involved_obj.get("apiVersion", "v1"))
+                involved_object_resource = find_resource(self.client, involved_obj["kind"], involved_obj.get("apiVersion", involved_obj["apiVersion"]))
                 if involved_object_resource:
                     api_involved_object = involved_object_resource.get(
                         name=involved_obj["name"], namespace=involved_obj["namespace"])


### PR DESCRIPTION
I noticed that the apiVersion for the involved object had been hard coded to v1; I found that for CR's where the ApiVersion was different I would get an error thrown on line 282 as 281 returned true but there was no .get attribute on the resource list.

My python skills aren't that great, so I'm not sure how 280 needs to be modified to fix the test though; testing the attribute exists seems a bit clunky though.