### PR TITLE
Swap out openshift client for kubernetes client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.7']
+        python_version: ['3.9']
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install ansible and kubernetes dependencies
-        run: pip install ansible~=2.9.27 yamllint kubernetes flake8 pycodestyle pylint
+        run: pip install ansible~=2.15.0 yamllint kubernetes flake8 pycodestyle pylint ansible-lint
 
       - name: Ensure collection dependency exists
         run: ansible-galaxy collection install kubernetes.core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install ansible and kubernetes dependencies
-        run: pip install ansible~=2.15.0 yamllint kubernetes flake8 pycodestyle pylint ansible-lint
+        run: pip install ansible-core~=2.15.0 yamllint kubernetes flake8 pycodestyle pylint ansible-lint
 
       - name: Ensure collection dependency exists
         run: ansible-galaxy collection install kubernetes.core
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.7']
+        python_version: ['3.9']
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install molecule and kubernetes dependencies
-        run: pip install ansible~=2.9.15 molecule yamllint kubernetes flake8
+        run: pip install ansible-core~=2.15.0 molecule yamllint kubernetes flake8
 
       - name: Ensure collection dependency exists
         run: ansible-galaxy collection install kubernetes.core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Install ansible and openshift dependencies
-        run: pip install ansible~=2.9.27 yamllint openshift flake8 pycodestyle pylint
+      - name: Install ansible and kubernetes dependencies
+        run: pip install ansible~=2.9.27 yamllint kubernetes flake8 pycodestyle pylint
 
       - name: Ensure collection dependency exists
-        run: ansible-galaxy collection install community.kubernetes
+        run: ansible-galaxy collection install kubernetes.core
 
       - name: Run sanity tests on Python ${{ matrix.python_version }}
         run: TEST_ARGS="--docker --color --python ${{ matrix.python_version }}" make test-sanity
@@ -54,11 +54,11 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Install molecule and openshift dependencies
-        run: pip install ansible~=2.9.15 molecule yamllint openshift flake8
+      - name: Install molecule and kubernetes dependencies
+        run: pip install ansible~=2.9.15 molecule yamllint kubernetes flake8
 
       - name: Ensure collection dependency exists
-        run: ansible-galaxy collection install community.kubernetes
+        run: ansible-galaxy collection install kubernetes.core
 
       - name: Run molecule default test scenario
         run: make test-molecule

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ release: build
 install: build
 	ansible-galaxy collection install -p ansible_collections operator_sdk-util-${VERSION}.tar.gz
 
-test-sanity: install
+test-lint: install
+	ansible-lint --profile safety
+
+test-sanity: test-lint
 	set -x && cd ansible_collections/operator_sdk/util && ansible-test sanity -v $(TEST_ARGS)
 
 test-molecule: install

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To run sanity tests locally, run
 make test-sanity
 ```
 
-To run the molecule integration tests, ensure you have molecule and the openshift python client installed and run
+To run the molecule integration tests, ensure you have molecule and the kubernetes python client installed and run
 
 ```
 make test-molecule

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: kubernetes.core

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -23,13 +23,15 @@
       k8s:
         src: files/crd.yaml
 
-    - block:
+    - name: Run doc examples tests
+      block:
         - name: Create namespace
           k8s:
             kind: Namespace
             name: osdkau-test-doc-examples
 
-        - import_tasks: tasks/doc_examples.yml
+        - name: Import doc examples tests
+          import_tasks: tasks/doc_examples.yml
           vars:
             namespace: osdkau-test-doc-examples
       always:
@@ -40,13 +42,15 @@
             state: absent
             wait: yes
 
-    - block:
+    - name: Run advanced usage tests
+      block:
         - name: Create namespace
           k8s:
             kind: Namespace
             name: osdkau-test-advanced-usage
 
-        - import_tasks: tasks/advanced_usage.yml
+        - name: Import advanced usage tests
+          import_tasks: tasks/advanced_usage.yml
           vars:
             namespace: osdkau-test-advanced-usage
       always:
@@ -57,13 +61,15 @@
             state: absent
             wait: yes
 
-    - block:
+    - name: Run expected failures testes
+      block:
         - name: Create namespace
           k8s:
             kind: Namespace
             name: osdkau-test-failure-modes
 
-        - import_tasks: tasks/failure_modes.yml
+        - name: Import expected failures tests
+          import_tasks: tasks/failure_modes.yml
           vars:
             namespace: osdkau-test-failure-modes
       always:
@@ -74,13 +80,15 @@
             state: absent
             wait: yes
 
-    - block:
+    - name: Run k8s events tests
+      block:
         - name: Create namespace
           k8s:
             kind: Namespace
             name: osdkau-test-k8s-events
 
-        - import_tasks: tasks/k8s_events.yml
+        - name: Import k8s events tests
+          import_tasks: tasks/k8s_events.yml
           vars:
             namespace: osdkau-test-k8s-events
       always:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
   gather_facts: no
 
   collections:
-    - community.kubernetes
+    - kubernetes.core
     - operator_sdk.util
 
   tasks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,7 +30,7 @@ provisioner:
 scenario:
   name: default
   test_sequence:
-    - lint
+    - dependency
     - syntax
     - converge
     - verify

--- a/molecule/default/tasks/advanced_usage.yml
+++ b/molecule/default/tasks/advanced_usage.yml
@@ -32,9 +32,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
+- name: Debug CR results
+  debug:
+    var: test_cr
 
-- assert:
+- name: Assert CR checks
+  assert:
     that:
       - test_cr.resources.0.status.hello == 'world'
       - condition.type == 'Available'
@@ -69,9 +72,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
+- name: Debug CR results
+  debug:
+    var: test_cr
 
-- assert:
+- name: Assert CR checks
+  assert:
     that:
       - test_cr.resources.0.status.hello == 'everybody'
       - (test_cr.resources.0.status.conditions | length) == 2
@@ -110,9 +116,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
+- name: Debug CR results
+  debug:
+    var: test_cr
 
-- assert:
+- name: Assert CR checks
+  assert:
     that:
       - test_cr.resources.0.status.hello is not defined
       - condition.type == 'Available'
@@ -145,9 +154,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
+- name: Debug CR results
+  debug:
+    var: test_cr
 
-- assert:
+- name: Assert CR checks
+  assert:
     that:
       - test_cr.resources.0.status.hello == 'world'
       - condition.type == 'Available'

--- a/molecule/default/tasks/doc_examples.yml
+++ b/molecule/default/tasks/doc_examples.yml
@@ -28,9 +28,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
+- name: Debug CR results
+  debug:
+    var: test_cr
 
-- assert:
+- name: Assert CR checks
+  assert:
     that:
       - test_cr.resources.0.status.hello == 'world'
       - test_cr.resources.0.status.custom == 'entries'
@@ -56,8 +59,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
-- assert:
+- name: Debug CR results
+  debug:
+    var: test_cr
+
+- name: Assert CR checks
+  assert:
     that:
       - condition.type == 'Running'
       - condition.status == 'True'
@@ -90,8 +97,12 @@
     namespace: '{{ namespace }}'
   register: test_cr
 
-- debug: var=test_cr
-- assert:
+- name: Debug CR results
+  debug:
+    var: test_cr
+
+- name: Assert CR checks
+  assert:
     that:
       - condition.type == 'Available'
       - condition.status == 'False'

--- a/molecule/default/tasks/failure_modes.yml
+++ b/molecule/default/tasks/failure_modes.yml
@@ -10,7 +10,8 @@
       spec:
         size: 2
 
-- block:
+- name: Test non-existant CR
+  block:
     - name: Set custom status fields on a CR that does not exist
       k8s_status:
         api_version: apps.example.com/v1alpha1
@@ -21,14 +22,16 @@
           hello: world
       register: test_cr_failed_1
   rescue:
-    - assert:
+    - name: Assert failures
+      assert:
         that:
           - test_cr_failed_1 is failed
           - test_cr_failed_1.msg == 'Failed to retrieve requested object'
           - test_cr_failed_1.error.status == 404
           - test_cr_failed_1.error.reason == 'Not Found'
 
-- block:
+- name: Test undefined CR
+  block:
     - name: Set custom status fields on a CR that is not defined
       k8s_status:
         api_version: apps.example.com/v1alpha1
@@ -39,12 +42,14 @@
           hello: world
       register: test_cr_failed_2
   rescue:
-    - assert:
+    - name: Assert failures
+      assert:
         that:
           - test_cr_failed_2 is failed
           - test_cr_failed_2.msg.startswith('Failed to find exact match for')
 
-- block:
+- name: Test multiple conditions
+  block:
     - name: Set conditions from the status and conditions fields
       k8s_status:
         api_version: apps.example.com/v1alpha1
@@ -64,11 +69,13 @@
             message: "The service did not respond to a ping"
       register: test_cr_failed_3
   rescue:
-    - assert:
+    - name: Assert failures
+      assert:
         that:
           - test_cr_failed_2 is failed
           - test_cr_failed_3.msg == "You cannot specify conditions in both the 'status' and 'conditions' parameters"
-- block:
+- name: Test invalid condition
+  block:
     - name: Set invalid reason on condition
       k8s_status:
         api_version: apps.example.com/v1alpha1
@@ -82,13 +89,15 @@
             message: "The service did not respond to a ping"
       register: test_cr_failed_4
   rescue:
-    - assert:
+    - name: Assert failures
+      assert:
         that:
           - test_cr_failed_4 is failed
           - test_cr_failed_4.msg == "The specified conditions failed to validate"
           - test_cr_failed_4.error == "Condition 'reason' must be a single, CamelCase word"
 
-- block:
+- name: Test invalid time
+  block:
     - name: Set invalid lastTransitionTime on condition
       k8s_status:
         api_version: apps.example.com/v1alpha1
@@ -103,7 +112,8 @@
             lastTransitionTime: "26/03/2021 2:00PM"
       register: test_cr_failed_5
   rescue:
-    - assert:
+    - name: Assert failures
+      assert:
         that:
           - test_cr_failed_5 is failed
           - test_cr_failed_5.msg == "The specified conditions failed to validate"

--- a/molecule/default/tasks/k8s_events.yml
+++ b/molecule/default/tasks/k8s_events.yml
@@ -29,9 +29,12 @@
     namespace: '{{ namespace }}'
   register: event_obj
 
-- debug: var=event_obj
+- name: Debug event results
+  debug:
+    var: event_obj
 
-- assert:
+- name: Assert event checks
+  assert:
     that:
       - event_obj.resources.0.metadata.name == 'test-name'
       - event_obj.resources.0.message == 'test-message'

--- a/plugins/doc_fragments/osdk_auth_options.py
+++ b/plugins/doc_fragments/osdk_auth_options.py
@@ -24,7 +24,7 @@ options:
   kubeconfig:
     description:
     - Path to an existing Kubernetes config file. If not provided, and no other connection
-      options are provided, the openshift client will attempt to load the default
+      options are provided, the kubernetes client will attempt to load the default
       configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG environment
       variable.
     type: path
@@ -88,9 +88,6 @@ options:
     - "The fix for this k8s python library is here: https://github.com/kubernetes-client/python-base/pull/169"
     type: bool
 notes:
-  - "The OpenShift Python client wraps the K8s Python client, providing full access to
-    all of the APIS and models available on both platforms. For API version details and
-    additional information visit https://github.com/openshift/openshift-restclient-python"
   - "To avoid SSL certificate validation errors when C(validate_certs) is I(True), the full
     certificate chain for the API server must be provided via C(ca_cert) or in the
     kubeconfig file."

--- a/plugins/module_utils/api_utils.py
+++ b/plugins/module_utils/api_utils.py
@@ -47,7 +47,7 @@ def get_api_client(module=None):
                 auth[true_name] = env_value
 
     def auth_set(*names):
-        return all([auth.get(name) for name in names])
+        return all(auth.get(name) for name in names)
 
     if auth_set('username', 'password', 'host') or auth_set('api_key', 'host'):
         # We have enough in the parameters to authenticate, no need to load incluster or kubeconfig

--- a/plugins/module_utils/api_utils.py
+++ b/plugins/module_utils/api_utils.py
@@ -16,8 +16,8 @@ try:
         AUTH_ARG_MAP,
     )
     import kubernetes
-    from openshift.dynamic import DynamicClient
-    from openshift.dynamic.exceptions import (ResourceNotFoundError, ResourceNotUniqueError)
+    from kubernetes.dynamic import DynamicClient
+    from kubernetes.dynamic.exceptions import (ResourceNotFoundError, ResourceNotUniqueError)
     HAS_K8S_MODULE_HELPER = True
     k8s_import_exception = None
 except ImportError as e:

--- a/plugins/modules/k8s_event.py
+++ b/plugins/modules/k8s_event.py
@@ -95,7 +95,7 @@ options:
 
 requirements:
   - python >= 2.7
-  - openshift >= 0.6.2
+  - kubernetes >= 25.3.0
 """
 
 EXAMPLES = """
@@ -185,7 +185,7 @@ try:
         get_api_client,
         find_resource,
     )
-    import openshift
+    import kubernetes
     HAS_K8S_MODULE_HELPER = True
     k8s_import_exception = None
 except ImportError as e:
@@ -261,7 +261,7 @@ class KubernetesEvent(AnsibleModule):
             prior_event = resource.get(
                 name=metadata["name"],
                 namespace=metadata["namespace"])
-        except openshift.dynamic.exceptions.NotFoundError:
+        except kubernetes.dynamic.exceptions.NotFoundError:
             pass
 
         prior_count = 1
@@ -285,7 +285,7 @@ class KubernetesEvent(AnsibleModule):
                     involved_obj["uid"] = api_involved_object["metadata"]["uid"]
                     involved_obj["resourceVersion"] = api_involved_object["metadata"]["resourceVersion"]
 
-            except openshift.dynamic.exceptions.NotFoundError:
+            except kubernetes.dynamic.exceptions.NotFoundError:
                 pass
 
         # Return data
@@ -300,7 +300,7 @@ class KubernetesEvent(AnsibleModule):
 
         try:
             instance = v1_events.get(name=self.params.get("name"), namespace=self.params.get("namespace"))
-        except openshift.dynamic.exceptions.NotFoundError:
+        except kubernetes.dynamic.exceptions.NotFoundError:
             try:
                 created_event = v1_events.create(body=event, namespace=self.params.get("namespace"))
                 return dict(result=created_event.to_dict(), changed=True)

--- a/plugins/modules/k8s_event.py
+++ b/plugins/modules/k8s_event.py
@@ -57,6 +57,7 @@ options:
     description:
     - Determines whether to override the default patch merge type with the specified.
     - The default is strategic merge.
+    elements: str
     choices:
       - "json"
       - "merge"
@@ -85,10 +86,31 @@ options:
   source:
     type: dict
     description: EventSource
-      - Component for reporting this Event
+    suboptions:
+      component:
+        description: Component for reporting this Event.
+        type: str
+        required: true
   involvedObject:
     type: dict
     description: The object that this event is about.
+    suboptions:
+      apiVersion:
+        description: The apiVersion.
+        type: str
+        required: true
+      kind:
+        description: Resource kind.
+        type: str
+        required: true
+      name:
+        description: Resource name.
+        type: str
+        required: true
+      namespace:
+        description: Resource namespace.
+        type: str
+        required: true
   appendTimestamp:
     type: bool
     description: Event name should have timestamp appended to it
@@ -126,51 +148,54 @@ result:
   returned: success
   type: complex
   contains:
-    contains:
-     namespace:
-       description: Namespace defines the space within which each name must be unique
-       returned: success
-       type: str
-     name:
-       description: The unique name of the resource.
-       returned: success
-       type: str
-     count:
-       description: Count of event occurrences
-       returned: success
-       type: int
-     message:
-       description: A human-readable description of the status of this operation.
-       returned: success
-       type: dict
-     kind:
-       description: Always 'Event'.
-       returned: success
-       type: str
-     firstTimestamp:
-       description: Timestamp of first occurrence of Event
-       returned: success
-       type: timestamp
-     reason:
-       description: Machine understandable string that gives the reason for the transition into the object's status.
-       returned: success
-       type: dict
-     reportingComponent:
-       description: Name of the controller that emitted this Event
-       returned: success
-     type:
-       description: Type of this event. New types could be added in the future.
-       returned: success
-     source:
-       description: The component reporting this event.
-       returned: success
-     lastTimestamp:
-       description: Timestamp of last occurrence of Event
-       returned: success
-       type: timestamp
-     involvedObject:
-       description: The object that this event is about.
-       returned: success
+   namespace:
+     description: Namespace defines the space within which each name must be unique
+     returned: success
+     type: str
+   name:
+     description: The unique name of the resource.
+     returned: success
+     type: str
+   count:
+     description: Count of event occurrences
+     returned: success
+     type: int
+   message:
+     description: A human-readable description of the status of this operation.
+     returned: success
+     type: dict
+   kind:
+     description: Always 'Event'.
+     returned: success
+     type: str
+   firstTimestamp:
+     description: Timestamp of first occurrence of Event
+     returned: success
+     type: str
+   reason:
+     description: Machine understandable string that gives the reason for the transition into the object's status.
+     returned: success
+     type: dict
+   reportingComponent:
+     description: Name of the controller that emitted this Event
+     returned: success
+     type: str
+   type:
+     description: Type of this event. New types could be added in the future.
+     returned: success
+     type: str
+   source:
+     description: The component reporting this event.
+     returned: success
+     type: dict
+   lastTimestamp:
+     description: Timestamp of last occurrence of Event
+     returned: success
+     type: str
+   involvedObject:
+     description: The object that this event is about.
+     returned: success
+     type: dict
 """
 
 import copy
@@ -197,7 +222,7 @@ EVENT_ARG_SPEC = {
     "state": {"default": "present", "choices": ["present", "absent"]},
     "name": {"required": True},
     "namespace": {"required": True},
-    "merge_type": {"type": "list", "choices": ["json", "merge", "strategic-merge"]},
+    "merge_type": {"type": "list", "elements": "str", "choices": ["json", "merge", "strategic-merge"]},
     "message": {"type": "str", "required": True},
     "reason": {"type": "str", "required": True},
     "reportingComponent": {"type": "str"},
@@ -205,14 +230,18 @@ EVENT_ARG_SPEC = {
     "appendTimestamp": {"type": "bool"},
     "source": {
         "type": "dict",
-        "component": {"type": "str", "required": True}
+        "options": {
+            "component": {"type": "str", "required": True}
+        }
     },
     "involvedObject": {
         "type": "dict",
-        "apiVersion": {"type": "str", "required": True},
-        "kind": {"type": "str", "required": True},
-        "name": {"type": "str", "required": True},
-        "namespace": {"type": "str", "required": True},
+        "options": {
+            "apiVersion": {"type": "str", "required": True},
+            "kind": {"type": "str", "required": True},
+            "name": {"type": "str", "required": True},
+            "namespace": {"type": "str", "required": True},
+        }
     }
 }
 

--- a/plugins/modules/k8s_status.py
+++ b/plugins/modules/k8s_status.py
@@ -414,14 +414,12 @@ class KubernetesAnsibleStatusModule(AnsibleModule):
     def object_contains(self, obj, subset):
         def dict_is_subset(obj, subset):
             return all(
-                [
-                    (
-                        mapping["default"]
-                        if self.replace_lists and isinstance(obj.get(k), list) and k != "conditions"
-                        else mapping.get(type(obj.get(k)), mapping["default"])
-                    )(obj.get(k), v)
-                    for (k, v) in subset.items()
-                ]
+                (
+                    mapping["default"]
+                    if self.replace_lists and isinstance(obj.get(k), list) and k != "conditions"
+                    else mapping.get(type(obj.get(k)), mapping["default"])
+                )(obj.get(k), v)
+                for (k, v) in subset.items()
             )
 
         def list_is_subset(obj, subset):

--- a/plugins/modules/k8s_status.py
+++ b/plugins/modules/k8s_status.py
@@ -93,7 +93,7 @@ options:
 
 requirements:
     - "python >= 3.7"
-    - "openshift >= 0.8.1"
+    - "kubernetes >= 25.3.0"
 """
 
 EXAMPLES = """
@@ -179,8 +179,8 @@ try:
         AUTH_ARG_SPEC,
         NAME_ARG_SPEC
     )
-    import openshift
-    from openshift.dynamic.exceptions import DynamicApiError
+    import kubernetes
+    from kubernetes.dynamic.exceptions import DynamicApiError
     HAS_K8S_MODULE_HELPER = True
     k8s_import_exception = None
 except ImportError as e:
@@ -285,10 +285,10 @@ class KubernetesAnsibleStatusModule(AnsibleModule):
         super(KubernetesAnsibleStatusModule, self).__init__(*args, argument_spec=self.argspec, **kwargs)
         if not HAS_K8S_MODULE_HELPER:
             self.fail_json(
-                msg=missing_required_lib('openshift'),
+                msg=missing_required_lib('kubernetes'),
                 exception=K8S_IMP_ERR,
                 error=to_native(k8s_import_exception))
-        self.openshift_version = openshift.__version__
+        self.kubernetes_version = kubernetes.__version__
 
         self.kind = self.params.get("kind")
         self.api_version = self.params.get("api_version")

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,7 @@
+plugins/modules/k8s_status.py validate-modules:missing-gplv3-license
+plugins/modules/requeue_after.py validate-modules:missing-gplv3-license
+plugins/modules/k8s_event.py validate-modules:missing-gplv3-license
+plugins/modules/k8s_event.py validate-modules:invalid-argument-name # message parameter not allowed
+plugins/modules/k8s_event.py validate-modules:nonexistent-parameter-documented
+plugins/modules/k8s_status.py validate-modules:invalid-argument-name # message parameter not allowed
+plugins/modules/k8s_status.py validate-modules:nonexistent-parameter-documented # message parameter not allowed


### PR DESCRIPTION
All the functionality provided by the openshift client library has been upstreamed to the kubernetes client library, so it's no longer necessary for both of these.

This also switches community.kubernetes to kubernetes.core as the former has been deprecated for some time now. This change only affects the testing and is a drop in replacement.