### PR TITLE
k8s_event.py: fix typo: merge_type

### DIFF
--- a/plugins/modules/k8s_event.py
+++ b/plugins/modules/k8s_event.py
@@ -127,7 +127,7 @@ EXAMPLES = """
     name: test-k8s-event
     namespace: default
     message: Event created
-    merge-type: strategic-merge
+    merge_type: strategic-merge
     reason: Testing event creation
     reportingComponent: Reporting components
     appendTimestamp: true


### PR DESCRIPTION
Hi,

This fixes a `-` / `_` error in the `k8s_event` example

Cheers,
Pierre